### PR TITLE
Update get_regvalue.py

### DIFF
--- a/get_regvalue.py
+++ b/get_regvalue.py
@@ -4,7 +4,9 @@ def get_regvalue(regkey, regvalue):
 
     explorer = _winreg.OpenKey(
         _winreg.HKEY_LOCAL_MACHINE,
-        regkey
+        regkey,
+        0,
+        _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY
     )
     
     value, type = _winreg.QueryValueEx(explorer, regvalue)


### PR DESCRIPTION
32bit python doesn't see 64bit registry by default