### PR TITLE
Remove X11 from build on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,7 +33,6 @@
             '-l<(MAGICK_ROOT)/lib/CORE_RL_magick_.lib',
             '-l<(MAGICK_ROOT)/lib/CORE_RL_Magick++_.lib',
             '-l<(MAGICK_ROOT)/lib/CORE_RL_wand_.lib',
-            '-l<(MAGICK_ROOT)/lib/X11.lib'
           ],
           'include_dirs': [
             '<(MAGICK_ROOT)/include',


### PR DESCRIPTION
The build on windows would fail because X11.lib is no longer included in the distribution.

* Visual Studio 2013
* Imagemagick 6.9.1-4 Q16 x64 DLL
* Python 2.7.5
* npm 2.5.1
* Windows 8.1 x64

With the proposed patch the build does succeed.

This would fix #90.

The output before this fix was:

```
PS D:\Programming\backend> npm install
\
> imagemagick-native@1.7.0 install D:\Programming\backend\node_modules\imagemagick-native
> node-gyp rebuild


D:\Programming\backend\node_modules\imagemagick-native>node "C:\Program Files\nodejs\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild
child_process: customFds option is deprecated, use stdio instead.
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
  imagemagick.cc
c:\program files\imagemagick-6.9.1-q16\include\magick/pixel-accessor.h(152): warning C4244: '=' : conversion from 'double' to 'MagickCore::MagickRealType', possible loss of data [D:\Programming\backend\node_modules\ imagemagick-native\build\imagemagick.vcxproj]
c:\program files\imagemagick-6.9.1-q16\include\magick/pixel-accessor.h(167): warning C4244: '=' : conversion from 'double' to 'MagickCore::MagickRealType', possible loss of data [D:\Programming\backend\node_modules\ imagemagick-native\build\imagemagick.vcxproj]
c:\program files\imagemagick-6.9.1-q16\include\magick/pixel-accessor.h(217): warning C4244: '=' : conversion from 'double' to 'MagickCore::MagickRealType', possible loss of data [D:\Programming\backend\node_modules\ imagemagick-native\build\imagemagick.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\xlocale(337): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc [D:\Programming\backend\node_modules\imagem agick-native\build\imagemagick.vcxproj]
D:\Programming\backend\node_modules\imagemagick-native\node_modules\nan\nan.h(665): warning C4244: 'return' : conversion from 'int64_t' to 'int', possible loss of data [D:\Programming\backend\node_mod ules\imagemagick-native\build\imagemagick.vcxproj]
..\src\imagemagick.cc(253): warning C4267: '=' : conversion from 'size_t' to 'unsigned int', possible loss of data [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
..\src\imagemagick.cc(254): warning C4267: '=' : conversion from 'size_t' to 'unsigned int', possible loss of data [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
..\src\imagemagick.cc(436): warning C4267: 'argument' : conversion from 'size_t' to 'uint32_t', possible loss of data [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
..\src\imagemagick.cc(562): warning C4267: 'argument' : conversion from 'size_t' to 'uint32_t', possible loss of data [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
..\src\imagemagick.cc(1015): warning C4267: 'argument' : conversion from 'size_t' to 'uint32_t', possible loss of data [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
D:\Programming\backend\node_modules\imagemagick-native\node_modules\nan\nan.h(327): warning C4267: 'argument' : conversion from 'size_t' to 'int32_t', possible loss of data [D:\Programming\backend\nod e_modules\imagemagick-native\build\imagemagick.vcxproj]
          ..\src\imagemagick.cc(612) : see reference to function template instantiation 'v8::Local<v8::Integer> NanNew<v8::Integer,size_t>(P)' being compiled
          with
          [
              P=size_t
          ]
LINK : fatal error LNK1181: cannot open input file 'C:\Program Files\ImageMagick-6.9.1-Q16\lib\X11.lib' [D:\Programming\backend\node_modules\imagemagick-native\build\imagemagick.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1067:12)
gyp ERR! System Windows_NT 6.3.9600
gyp ERR! command "node" "C:\\Program Files\\nodejs\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd D:\Programming\backend\node_modules\imagemagick-native
gyp ERR! node -v v0.12.0
gyp ERR! node-gyp -v v1.0.2
gyp ERR! not ok
npm ERR! Windows_NT 6.3.9600
npm ERR! argv "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code ELIFECYCLE

npm ERR! imagemagick-native@1.7.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the imagemagick-native@1.7.0 install script 'node-gyp rebuild'.
npm ERR! This is most likely a problem with the imagemagick-native package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls imagemagick-native
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     D:\Programming\backend\npm-debug.log
```